### PR TITLE
feat: add sport tracking module

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/lifebalancer?schema=public"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # lifeBalancer
-lifeBalance
+
+Basic Express + Prisma backend for tracking workouts.
+
+## Development
+
+```bash
+npm install
+npm run prisma:generate
+npm run prisma:migrate
+npm run db:seed
+npm run dev
+```
+
+### API
+
+- `GET /api/sport/exercises`
+- `POST /api/sport/workouts`
+- `GET /api/sport/workouts`
+- `GET /api/sport/progress/:exerciseId`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^5.16.1",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -20,8 +21,23 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "prettier": "^3.6.2",
+        "prisma": "^5.16.1",
+        "ts-node": "^10.9.2",
         "tsx": "^4.19.0",
         "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -718,6 +734,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -768,6 +812,102 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -1161,6 +1301,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1193,6 +1346,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1382,6 +1542,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1428,6 +1595,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2399,6 +2576,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2696,6 +2880,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/proxy-addr": {
@@ -3115,6 +3319,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.20.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
@@ -3202,6 +3450,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3242,6 +3497,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,18 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint \"src/**/*.ts\"",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "db:seed": "node --loader ts-node/esm prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "@prisma/client": "^5.16.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
@@ -27,6 +31,8 @@
     "eslint-plugin-prettier": "^5.5.4",
     "prettier": "^3.6.2",
     "tsx": "^4.19.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "prisma": "^5.16.1",
+    "ts-node": "^10.9.2"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,164 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UnitSystem {
+  METRIC
+  IMPERIAL
+}
+
+enum ExerciseType {
+  STRENGTH
+  CARDIO
+  MOBILITY
+}
+
+enum SetType {
+  WARMUP
+  WORKING
+  DROP
+  BACKOFF
+  FAILURE
+  COOLDOWN
+}
+
+enum Side {
+  LEFT
+  RIGHT
+  BOTH
+}
+
+enum OneRmFormula {
+  EPLEY
+  BRZYCKI
+  OCONNOR
+}
+
+model User {
+  id           String   @id @default(cuid())
+  email        String   @unique
+  displayName  String?
+  unitSystem   UnitSystem @default(METRIC)
+  createdAt    DateTime @default(now())
+  workouts     Workout[]
+}
+
+model Equipment {
+  id          String  @id @default(cuid())
+  name        String  @unique
+  barWeightKg Float?
+  metadata    Json?
+  exercises   Exercise[]
+}
+
+model MuscleGroup {
+  id      String  @id @default(cuid())
+  name    String  @unique
+  muscles Muscle[]
+}
+
+model Muscle {
+  id        String       @id @default(cuid())
+  name      String
+  group     MuscleGroup  @relation(fields: [groupId], references: [id])
+  groupId   String
+  exercises ExerciseMuscle[]
+  @@unique([name, groupId])
+}
+
+model Exercise {
+  id                 String  @id @default(cuid())
+  slug               String  @unique
+  name               String
+  type               ExerciseType
+  defaultEquipmentId String?
+  defaultEquipment   Equipment? @relation(fields: [defaultEquipmentId], references: [id])
+  unilateral         Boolean @default(false)
+  metrics            Json     // { weight: true, reps: true, duration: false, ... }
+  muscles            ExerciseMuscle[]
+  workoutExercises   WorkoutExercise[]
+  oneRmEstimates     OneRmEstimate[]
+}
+
+model ExerciseMuscle {
+  exercise   Exercise @relation(fields: [exerciseId], references: [id])
+  exerciseId String
+  muscle     Muscle   @relation(fields: [muscleId], references: [id])
+  muscleId   String
+  role       String   // 'PRIMARY' | 'SECONDARY'
+  @@id([exerciseId, muscleId])
+}
+
+model Workout {
+  id             String   @id @default(cuid())
+  user           User     @relation(fields: [userId], references: [id])
+  userId         String
+  startedAt      DateTime @default(now())
+  completedAt    DateTime?
+  bodyweightKg   Float?
+  mood           Int?
+  soreness       Int?
+  energy         Int?
+  notes          String?
+  totalVolumeKg  Float    @default(0)
+  totalReps      Int      @default(0)
+  totalSets      Int      @default(0)
+  durationSec    Int      @default(0)
+  exercises      WorkoutExercise[]
+  oneRmEstimates OneRmEstimate[]
+}
+
+model WorkoutExercise {
+  id            String   @id @default(cuid())
+  workout       Workout  @relation(fields: [workoutId], references: [id])
+  workoutId     String
+  exercise      Exercise @relation(fields: [exerciseId], references: [id])
+  exerciseId    String
+  orderIndex    Int
+  supersetGroup Int?
+  notes         String?
+  sets          Set[]
+}
+
+model Set {
+  id                 String   @id @default(cuid())
+  workoutExercise    WorkoutExercise @relation(fields: [workoutExerciseId], references: [id])
+  workoutExerciseId  String
+  setIndex           Int
+  setType            SetType
+  side               Side     @default(BOTH)
+  weightKg           Float?
+  repsTarget         Int?
+  repsActual         Int?
+  distanceM          Int?
+  durationSec        Int?
+  rpe                Float?
+  rir                Float?
+  pct1RmTarget       Float?
+  restPlannedSec     Int?
+  restActualSec      Int?
+  tempo              String?
+  assistanceKg       Float?
+  isPr               Boolean  @default(false)
+  notes              String?
+  oneRmEstimates     OneRmEstimate[]
+}
+
+model OneRmEstimate {
+  id           String   @id @default(cuid())
+  workout      Workout  @relation(fields: [workoutId], references: [id])
+  workoutId    String
+  exercise     Exercise @relation(fields: [exerciseId], references: [id])
+  exerciseId   String
+  set          Set?     @relation(fields: [setId], references: [id])
+  setId        String?
+  formula      OneRmFormula
+  estimatedKg  Float
+  date         DateTime @default(now())
+  @@index([workoutId, exerciseId, date])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const chest = await prisma.muscleGroup.upsert({
+    where: { name: 'Chest' },
+    update: {},
+    create: { name: 'Chest', muscles: { create: [{ name: 'Pectoralis major' }] } },
+  });
+  const barbell = await prisma.equipment.upsert({
+    where: { name: 'Barbell' },
+    update: {},
+    create: { name: 'Barbell', barWeightKg: 20 },
+  });
+  await prisma.exercise.upsert({
+    where: { slug: 'barbell-bench-press' },
+    update: {},
+    create: {
+      slug: 'barbell-bench-press',
+      name: 'Barbell Bench Press',
+      type: 'STRENGTH',
+      defaultEquipmentId: barbell.id,
+      unilateral: false,
+      metrics: { weight: true, reps: true, duration: false },
+      muscles: { create: [{ muscleId: chest.muscles[0].id, role: 'PRIMARY' }] },
+    },
+  });
+}
+
+main().finally(() => prisma.$disconnect());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import express from 'express';
+import sportRoutes from './modules/sport/routes.js';
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/api/sport', sportRoutes);
 
 app.get('/', (_req, res) => {
   res.send('Hello, world!');

--- a/src/modules/sport/routes.ts
+++ b/src/modules/sport/routes.ts
@@ -1,0 +1,46 @@
+import { Router, Request, Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { createWorkout } from './service.js';
+
+interface AuthedRequest extends Request {
+  user?: { id: string };
+}
+
+const prisma = new PrismaClient();
+const r = Router();
+
+r.get('/exercises', async (_req: Request, res: Response) => {
+  const list = await prisma.exercise.findMany({ include: { muscles: true } });
+  res.json(list);
+});
+
+r.post('/workouts', async (req: AuthedRequest, res: Response) => {
+  const userId = req.user?.id || 'demo-user';
+  const out = await createWorkout(userId, req.body);
+  res.status(201).json(out);
+});
+
+r.get('/workouts', async (req: AuthedRequest, res: Response) => {
+  const userId = req.user?.id || 'demo-user';
+  const ws = await prisma.workout.findMany({
+    where: { userId },
+    orderBy: { startedAt: 'desc' },
+    include: {
+      exercises: { include: { sets: true, exercise: true } },
+      oneRmEstimates: true,
+    },
+  });
+  res.json(ws);
+});
+
+r.get('/progress/:exerciseId', async (req: AuthedRequest, res: Response) => {
+  const userId = req.user?.id || 'demo-user';
+  const { exerciseId } = req.params;
+  const est = await prisma.oneRmEstimate.findMany({
+    where: { exerciseId, workout: { userId } },
+    orderBy: { date: 'asc' },
+  });
+  res.json({ oneRm: est, last: est.at(-1) ?? null });
+});
+
+export default r;

--- a/src/modules/sport/service.ts
+++ b/src/modules/sport/service.ts
@@ -1,0 +1,106 @@
+import { PrismaClient, OneRmFormula } from '@prisma/client';
+const prisma = new PrismaClient();
+
+// Epley: 1RM = w * (1 + reps/30)
+const epley1RM = (w: number, reps: number) =>
+  reps > 1 ? w * (1 + reps / 30) : w;
+
+export async function createWorkout(
+  userId: string,
+  payload: {
+    bodyweightKg?: number;
+    notes?: string;
+    exercises: Array<{
+      exerciseId: string;
+      orderIndex: number;
+      supersetGroup?: number;
+      sets: Array<{
+        setIndex: number;
+        setType:
+          | 'WARMUP'
+          | 'WORKING'
+          | 'DROP'
+          | 'BACKOFF'
+          | 'FAILURE'
+          | 'COOLDOWN';
+        side?: 'LEFT' | 'RIGHT' | 'BOTH';
+        weightKg?: number;
+        repsActual?: number;
+        repsTarget?: number;
+        rpe?: number;
+        rir?: number;
+        durationSec?: number;
+        distanceM?: number;
+        restPlannedSec?: number;
+        restActualSec?: number;
+        assistanceKg?: number;
+        tempo?: string;
+        notes?: string;
+      }>;
+    }>;
+  },
+) {
+  const workout = await prisma.workout.create({
+    data: {
+      userId,
+      bodyweightKg: payload.bodyweightKg,
+      notes: payload.notes ?? '',
+      exercises: {
+        create: payload.exercises.map((ex) => ({
+          exerciseId: ex.exerciseId,
+          orderIndex: ex.orderIndex,
+          supersetGroup: ex.supersetGroup ?? null,
+          sets: {
+            create: ex.sets.map((s) => ({ ...s, side: s.side ?? 'BOTH' })),
+          },
+        })),
+      },
+    },
+    include: { exercises: { include: { sets: true, exercise: true } } },
+  });
+
+  let totalVolumeKg = 0,
+    totalReps = 0,
+    totalSets = 0;
+  const oneRmEstimates: Array<{
+    workoutId: string;
+    exerciseId: string;
+    setId: string;
+    formula: OneRmFormula;
+    estimatedKg: number;
+  }> = [];
+
+  workout.exercises.forEach((wex) => {
+    wex.sets.forEach((set) => {
+      totalSets += 1;
+      if (set.repsActual) totalReps += set.repsActual;
+      if (set.weightKg && set.repsActual) {
+        totalVolumeKg += set.weightKg * set.repsActual;
+        const est = epley1RM(set.weightKg, set.repsActual);
+        oneRmEstimates.push({
+          workoutId: workout.id,
+          exerciseId: wex.exerciseId,
+          setId: set.id,
+          formula: 'EPLEY',
+          estimatedKg: Math.round(est * 100) / 100,
+        });
+      }
+    });
+  });
+
+  await prisma.$transaction([
+    prisma.workout.update({
+      where: { id: workout.id },
+      data: { totalVolumeKg, totalReps, totalSets },
+    }),
+    ...oneRmEstimates.map((e) => prisma.oneRmEstimate.create({ data: e })),
+  ]);
+
+  return prisma.workout.findUnique({
+    where: { id: workout.id },
+    include: {
+      exercises: { include: { sets: true, exercise: true } },
+      oneRmEstimates: true,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Prisma and seed data for workout tracking
- add sport service to record workouts and estimate 1RM
- expose sport routes and mount them on `/api/sport`

## Testing
- `npm run prisma:generate`
- `npm run prisma:migrate` *(fails: Can't reach database server at `localhost:5432`)*
- `npm run db:seed` *(fails: Node error due to missing database)*
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b8bc2c3d8832b9875315357eb9036