### PR TITLE
Log seeding errors during Prisma seed

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,4 +36,11 @@ async function main() {
   });
 }
 
-main().finally(() => prisma.$disconnect());
+main()
+  .catch((err) => {
+    console.error('Seeding failed:', err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- log seeding failures and exit non-zero
- ensure Prisma disconnects on seed completion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba2848734832b849dc7055809cd34