### PR TITLE
Log seeding errors during Prisma seed

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,39 +1,50 @@
+import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
-const prisma = new PrismaClient();
 
 async function main() {
-  await prisma.user.upsert({
-    where: { id: 'demo-user' },
-    update: {},
-    create: {
-      id: 'demo-user',
-      email: 'demo@example.com',
-      displayName: 'Demo User',
-    },
-  });
-  const chest = await prisma.muscleGroup.upsert({
-    where: { name: 'Chest' },
-    update: {},
-    create: { name: 'Chest', muscles: { create: [{ name: 'Pectoralis major' }] } },
-  });
-  const barbell = await prisma.equipment.upsert({
-    where: { name: 'Barbell' },
-    update: {},
-    create: { name: 'Barbell', barWeightKg: 20 },
-  });
-  await prisma.exercise.upsert({
-    where: { slug: 'barbell-bench-press' },
-    update: {},
-    create: {
-      slug: 'barbell-bench-press',
-      name: 'Barbell Bench Press',
-      type: 'STRENGTH',
-      defaultEquipmentId: barbell.id,
-      unilateral: false,
-      metrics: { weight: true, reps: true, duration: false },
-      muscles: { create: [{ muscleId: chest.muscles[0].id, role: 'PRIMARY' }] },
-    },
-  });
+  const prisma = new PrismaClient();
+  try {
+    await prisma.user.upsert({
+      where: { id: 'demo-user' },
+      update: {},
+      create: {
+        id: 'demo-user',
+        email: 'demo@example.com',
+        displayName: 'Demo User',
+      },
+    });
+
+    const chest = await prisma.muscleGroup.upsert({
+      where: { name: 'Chest' },
+      update: {},
+      create: { name: 'Chest', muscles: { create: [{ name: 'Pectoralis major' }] } },
+    });
+
+    const barbell = await prisma.equipment.upsert({
+      where: { name: 'Barbell' },
+      update: {},
+      create: { name: 'Barbell', barWeightKg: 20 },
+    });
+
+    await prisma.exercise.upsert({
+      where: { slug: 'barbell-bench-press' },
+      update: {},
+      create: {
+        slug: 'barbell-bench-press',
+        name: 'Barbell Bench Press',
+        type: 'STRENGTH',
+        defaultEquipmentId: barbell.id,
+        unilateral: false,
+        metrics: { weight: true, reps: true, duration: false },
+        muscles: { create: [{ muscleId: chest.muscles[0].id, role: 'PRIMARY' }] },
+      },
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
 }
 
-main().finally(() => prisma.$disconnect());
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- load environment variables before seeding
- ensure Prisma client closes and errors are logged

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba2848734832b849dc7055809cd34