### PR TITLE
chore: wait for database in demo workflow

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -30,6 +30,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run prisma:generate
+      - run: npx wait-on tcp:localhost:5432
       - run: npx prisma db push
       - run: npm run db:seed
       - run: npm run build


### PR DESCRIPTION
## Summary
- ensure demo workflow waits for postgres to accept connections before pushing schema

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc0a34d54832b9b256f486204977d